### PR TITLE
Additional URL fixes

### DIFF
--- a/beanstalk
+++ b/beanstalk
@@ -389,7 +389,7 @@ class Beanstalk
 					if ($type == 'SVN') { 
 						$_message .=' https://'.$this->beanstalk_username.'@'.$this->beanstalk_account.'.svn.beanstalkapp.com/'.$repo->name.'/';
 					} else {
-						$_message .=' - git@'.$this->beanstalk_account.'beanstalkapp.com:/'.$repo->name.'.git';
+						$_message .=' - git@'.$this->beanstalk_account.'.beanstalkapp.com:/'.$repo->name.'.git';
 					}
 					$_message .= "\n";
 						
@@ -818,7 +818,7 @@ class Beanstalk
 		if ($type == 'SVN') { 
 			$path ='https://'.$this->beanstalk_username.'@'.$this->beanstalk_account.'.svn.beanstalkapp.com/'.$repo->name.'/';
 		} else {
-			$path ='git@'.$this->beanstalk_account.'beanstakapp.com:/'.$repo->name.'.git';
+			$path ='git@'.$this->beanstalk_account.'.beanstalkapp.com:/'.$repo->name.'.git';
 		}
 		
 		self::_display_message('', 'Path: '.$path);
@@ -864,7 +864,7 @@ class Beanstalk
 				if ($type == 'SVN') { 
 					$_message .=' https://'.$this->beanstalk_username.'@'.$this->beanstalk_account.'.svn.beanstalkapp.com/'.$repo->name.'/';
 				} else {
-					$_message .=' - git@'.$this->beanstalk_account.'beanstakapp.com:/'.$repo->name.'.git';
+					$_message .=' - git@'.$this->beanstalk_account.'.beanstalkapp.com:/'.$repo->name.'.git';
 				}
 				$_message .= "\n";
 					


### PR DESCRIPTION
Fixes #5 by...
- Correcting incorrect URLs containing 'beanstak' to 'beanstalk'
- Adding period separator to URLs between subdomain and 'beanstalkapp.com'
